### PR TITLE
updated prefix-scan kernel to put barriers in for loops in up/down sweep phases

### DIFF
--- a/prefix-scan/include/kernels.clh
+++ b/prefix-scan/include/kernels.clh
@@ -34,9 +34,8 @@ __kernel void prefixSum(__global int* data, const int n)
                 local_data[i] += local_data[i - p/2];
             }
         }
+        barrier(CLK_LOCAL_MEM_FENCE);
     }
-
-    barrier(CLK_LOCAL_MEM_FENCE);
 
     // down-sweep phase
     for (int p = n/2; p >= 2; p /= 2)
@@ -48,9 +47,8 @@ __kernel void prefixSum(__global int* data, const int n)
                 local_data[i + p/2] += local_data[i];
             }
         }
+        barrier(CLK_LOCAL_MEM_FENCE);
     }
-
-    barrier(CLK_LOCAL_MEM_FENCE);
     
     // Update the global memory with the valid copy of local memory
     for (int i = global_id; i < n; i += global_size)


### PR DESCRIPTION
updated barriers to guarantee correctness